### PR TITLE
Refine image loading and add Flutter setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Install basic dependencies for Flutter
+apt-get update
+apt-get install -y --no-install-recommends curl git unzip xz-utils
+
+# Download Flutter SDK if not present
+if [ ! -d "$HOME/flutter" ]; then
+  curl -L https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.22.0-stable.tar.xz -o /tmp/flutter.tar.xz
+  mkdir -p "$HOME"
+  tar xf /tmp/flutter.tar.xz -C "$HOME"
+fi
+
+export PATH="$HOME/flutter/bin:$PATH"
+
+# Run Flutter tool to download packages
+if [ -f "deetox/pubspec.yaml" ]; then
+  (cd deetox && flutter pub get)
+fi


### PR DESCRIPTION
## Summary
- simplify Appwrite preview URL generation for lesson images
- add a setup script to install Flutter SDK and dependencies

## Testing
- `bash setup.sh` *(fails: CONNECT tunnel failed)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f53f37198832c8a3180c7230969d9